### PR TITLE
fix: ip_restriction block

### DIFF
--- a/modules/container-web-app/r-appservice.tf
+++ b/modules/container-web-app/r-appservice.tf
@@ -25,10 +25,34 @@ resource "azurerm_linux_web_app" "app_service_linux_container" {
       use_32_bit_worker        = lookup(site_config.value, "use_32_bit_worker", false)
       websockets_enabled       = lookup(site_config.value, "websockets_enabled", false)
 
-      ip_restriction              = concat(local.subnets, local.cidrs, local.service_tags)
       scm_type                    = lookup(site_config.value, "scm_type", null)
       scm_use_main_ip_restriction = length(var.scm_authorized_ips) > 0 || var.scm_authorized_subnet_ids != null ? false : true
-      scm_ip_restriction          = concat(local.scm_subnets, local.scm_cidrs, local.scm_service_tags)
+
+      dynamic "ip_restriction" {
+        for_each = concat(local.subnets, local.cidrs, local.service_tags)
+        content {
+          name                      = ip_restriction.value.name
+          ip_address                = ip_restriction.value.ip_address
+          virtual_network_subnet_id = ip_restriction.value.virtual_network_subnet_id
+          service_tag               = ip_restriction.value.service_tag
+          priority                  = ip_restriction.value.priority
+          action                    = ip_restriction.value.action
+          headers                   = ip_restriction.value.headers
+        }
+      }
+
+      dynamic "scm_ip_restriction" {
+        for_each = concat(local.scm_subnets, local.scm_cidrs, local.scm_service_tags)
+        content {
+          name                      = scm_ip_restriction.value.name
+          ip_address                = scm_ip_restriction.value.ip_address
+          virtual_network_subnet_id = scm_ip_restriction.value.virtual_network_subnet_id
+          service_tag               = scm_ip_restriction.value.service_tag
+          priority                  = scm_ip_restriction.value.priority
+          action                    = scm_ip_restriction.value.action
+          headers                   = scm_ip_restriction.value.headers
+        }
+      }
 
       vnet_route_all_enabled = var.app_service_vnet_integration_subnet_id != null
 
@@ -199,10 +223,34 @@ resource "azurerm_linux_web_app_slot" "app_service_linux_container_slot" {
       use_32_bit_worker        = lookup(site_config.value, "use_32_bit_worker", false)
       websockets_enabled       = lookup(site_config.value, "websockets_enabled", false)
 
-      ip_restriction              = concat(local.subnets, local.cidrs, local.service_tags)
       scm_type                    = lookup(site_config.value, "scm_type", null)
       scm_use_main_ip_restriction = length(var.scm_authorized_ips) > 0 || var.scm_authorized_subnet_ids != null ? false : true
-      scm_ip_restriction          = concat(local.scm_subnets, local.scm_cidrs, local.scm_service_tags)
+
+      dynamic "ip_restriction" {
+        for_each = concat(local.subnets, local.cidrs, local.service_tags)
+        content {
+          name                      = ip_restriction.value.name
+          ip_address                = ip_restriction.value.ip_address
+          virtual_network_subnet_id = ip_restriction.value.virtual_network_subnet_id
+          service_tag               = ip_restriction.value.service_tag
+          priority                  = ip_restriction.value.priority
+          action                    = ip_restriction.value.action
+          headers                   = ip_restriction.value.headers
+        }
+      }
+
+      dynamic "scm_ip_restriction" {
+        for_each = concat(local.scm_subnets, local.scm_cidrs, local.scm_service_tags)
+        content {
+          name                      = scm_ip_restriction.value.name
+          ip_address                = scm_ip_restriction.value.ip_address
+          virtual_network_subnet_id = scm_ip_restriction.value.virtual_network_subnet_id
+          service_tag               = scm_ip_restriction.value.service_tag
+          priority                  = scm_ip_restriction.value.priority
+          action                    = scm_ip_restriction.value.action
+          headers                   = scm_ip_restriction.value.headers
+        }
+      }
 
       vnet_route_all_enabled = var.app_service_vnet_integration_subnet_id != null
 

--- a/modules/container-web-app/r-appservice.tf
+++ b/modules/container-web-app/r-appservice.tf
@@ -54,7 +54,6 @@ resource "azurerm_linux_web_app" "app_service_linux_container" {
       scm_type                    = lookup(site_config.value, "scm_type", null)
       scm_use_main_ip_restriction = length(var.scm_authorized_ips) > 0 || var.scm_authorized_subnet_ids != null ? false : true
 
-
       vnet_route_all_enabled = var.app_service_vnet_integration_subnet_id != null
 
       application_stack {
@@ -252,7 +251,6 @@ resource "azurerm_linux_web_app_slot" "app_service_linux_container_slot" {
 
       scm_type                    = lookup(site_config.value, "scm_type", null)
       scm_use_main_ip_restriction = length(var.scm_authorized_ips) > 0 || var.scm_authorized_subnet_ids != null ? false : true
-
 
       vnet_route_all_enabled = var.app_service_vnet_integration_subnet_id != null
 

--- a/modules/container-web-app/r-appservice.tf
+++ b/modules/container-web-app/r-appservice.tf
@@ -25,9 +25,6 @@ resource "azurerm_linux_web_app" "app_service_linux_container" {
       use_32_bit_worker        = lookup(site_config.value, "use_32_bit_worker", false)
       websockets_enabled       = lookup(site_config.value, "websockets_enabled", false)
 
-      scm_type                    = lookup(site_config.value, "scm_type", null)
-      scm_use_main_ip_restriction = length(var.scm_authorized_ips) > 0 || var.scm_authorized_subnet_ids != null ? false : true
-
       dynamic "ip_restriction" {
         for_each = concat(local.subnets, local.cidrs, local.service_tags)
         content {
@@ -53,6 +50,10 @@ resource "azurerm_linux_web_app" "app_service_linux_container" {
           headers                   = scm_ip_restriction.value.headers
         }
       }
+
+      scm_type                    = lookup(site_config.value, "scm_type", null)
+      scm_use_main_ip_restriction = length(var.scm_authorized_ips) > 0 || var.scm_authorized_subnet_ids != null ? false : true
+
 
       vnet_route_all_enabled = var.app_service_vnet_integration_subnet_id != null
 
@@ -223,9 +224,6 @@ resource "azurerm_linux_web_app_slot" "app_service_linux_container_slot" {
       use_32_bit_worker        = lookup(site_config.value, "use_32_bit_worker", false)
       websockets_enabled       = lookup(site_config.value, "websockets_enabled", false)
 
-      scm_type                    = lookup(site_config.value, "scm_type", null)
-      scm_use_main_ip_restriction = length(var.scm_authorized_ips) > 0 || var.scm_authorized_subnet_ids != null ? false : true
-
       dynamic "ip_restriction" {
         for_each = concat(local.subnets, local.cidrs, local.service_tags)
         content {
@@ -251,6 +249,10 @@ resource "azurerm_linux_web_app_slot" "app_service_linux_container_slot" {
           headers                   = scm_ip_restriction.value.headers
         }
       }
+
+      scm_type                    = lookup(site_config.value, "scm_type", null)
+      scm_use_main_ip_restriction = length(var.scm_authorized_ips) > 0 || var.scm_authorized_subnet_ids != null ? false : true
+
 
       vnet_route_all_enabled = var.app_service_vnet_integration_subnet_id != null
 

--- a/modules/linux-web-app/r-appservice.tf
+++ b/modules/linux-web-app/r-appservice.tf
@@ -53,7 +53,6 @@ resource "azurerm_linux_web_app" "app_service_linux" {
       scm_type                    = lookup(site_config.value, "scm_type", null)
       scm_use_main_ip_restriction = length(var.scm_authorized_ips) > 0 || var.scm_authorized_subnet_ids != null ? false : true
 
-
       vnet_route_all_enabled = var.app_service_vnet_integration_subnet_id != null
 
       dynamic "application_stack" {
@@ -259,7 +258,6 @@ resource "azurerm_linux_web_app_slot" "app_service_linux_slot" {
 
       scm_type                    = lookup(site_config.value, "scm_type", null)
       scm_use_main_ip_restriction = length(var.scm_authorized_ips) > 0 || var.scm_authorized_subnet_ids != null ? false : true
-
 
       vnet_route_all_enabled = var.app_service_vnet_integration_subnet_id != null
 

--- a/modules/linux-web-app/r-appservice.tf
+++ b/modules/linux-web-app/r-appservice.tf
@@ -24,10 +24,34 @@ resource "azurerm_linux_web_app" "app_service_linux" {
       use_32_bit_worker        = lookup(site_config.value, "use_32_bit_worker", false)
       websockets_enabled       = lookup(site_config.value, "websockets_enabled", false)
 
-      ip_restriction              = concat(local.subnets, local.cidrs, local.service_tags)
       scm_type                    = lookup(site_config.value, "scm_type", null)
       scm_use_main_ip_restriction = length(var.scm_authorized_ips) > 0 || var.scm_authorized_subnet_ids != null ? false : true
-      scm_ip_restriction          = concat(local.scm_subnets, local.scm_cidrs, local.scm_service_tags)
+
+      dynamic "ip_restriction" {
+        for_each = concat(local.subnets, local.cidrs, local.service_tags)
+        content {
+          name                      = ip_restriction.value.name
+          ip_address                = ip_restriction.value.ip_address
+          virtual_network_subnet_id = ip_restriction.value.virtual_network_subnet_id
+          service_tag               = ip_restriction.value.service_tag
+          priority                  = ip_restriction.value.priority
+          action                    = ip_restriction.value.action
+          headers                   = ip_restriction.value.headers
+        }
+      }
+
+      dynamic "scm_ip_restriction" {
+        for_each = concat(local.scm_subnets, local.scm_cidrs, local.scm_service_tags)
+        content {
+          name                      = scm_ip_restriction.value.name
+          ip_address                = scm_ip_restriction.value.ip_address
+          virtual_network_subnet_id = scm_ip_restriction.value.virtual_network_subnet_id
+          service_tag               = scm_ip_restriction.value.service_tag
+          priority                  = scm_ip_restriction.value.priority
+          action                    = scm_ip_restriction.value.action
+          headers                   = scm_ip_restriction.value.headers
+        }
+      }
 
       vnet_route_all_enabled = var.app_service_vnet_integration_subnet_id != null
 
@@ -206,10 +230,34 @@ resource "azurerm_linux_web_app_slot" "app_service_linux_slot" {
       use_32_bit_worker        = lookup(site_config.value, "use_32_bit_worker", false)
       websockets_enabled       = lookup(site_config.value, "websockets_enabled", false)
 
-      ip_restriction              = concat(local.subnets, local.cidrs, local.service_tags)
       scm_type                    = lookup(site_config.value, "scm_type", null)
       scm_use_main_ip_restriction = length(var.scm_authorized_ips) > 0 || var.scm_authorized_subnet_ids != null ? false : true
-      scm_ip_restriction          = concat(local.scm_subnets, local.scm_cidrs, local.scm_service_tags)
+
+      dynamic "ip_restriction" {
+        for_each = concat(local.subnets, local.cidrs, local.service_tags)
+        content {
+          name                      = ip_restriction.value.name
+          ip_address                = ip_restriction.value.ip_address
+          virtual_network_subnet_id = ip_restriction.value.virtual_network_subnet_id
+          service_tag               = ip_restriction.value.service_tag
+          priority                  = ip_restriction.value.priority
+          action                    = ip_restriction.value.action
+          headers                   = ip_restriction.value.headers
+        }
+      }
+
+      dynamic "scm_ip_restriction" {
+        for_each = concat(local.scm_subnets, local.scm_cidrs, local.scm_service_tags)
+        content {
+          name                      = scm_ip_restriction.value.name
+          ip_address                = scm_ip_restriction.value.ip_address
+          virtual_network_subnet_id = scm_ip_restriction.value.virtual_network_subnet_id
+          service_tag               = scm_ip_restriction.value.service_tag
+          priority                  = scm_ip_restriction.value.priority
+          action                    = scm_ip_restriction.value.action
+          headers                   = scm_ip_restriction.value.headers
+        }
+      }
 
       vnet_route_all_enabled = var.app_service_vnet_integration_subnet_id != null
 

--- a/modules/linux-web-app/r-appservice.tf
+++ b/modules/linux-web-app/r-appservice.tf
@@ -24,9 +24,6 @@ resource "azurerm_linux_web_app" "app_service_linux" {
       use_32_bit_worker        = lookup(site_config.value, "use_32_bit_worker", false)
       websockets_enabled       = lookup(site_config.value, "websockets_enabled", false)
 
-      scm_type                    = lookup(site_config.value, "scm_type", null)
-      scm_use_main_ip_restriction = length(var.scm_authorized_ips) > 0 || var.scm_authorized_subnet_ids != null ? false : true
-
       dynamic "ip_restriction" {
         for_each = concat(local.subnets, local.cidrs, local.service_tags)
         content {
@@ -52,6 +49,10 @@ resource "azurerm_linux_web_app" "app_service_linux" {
           headers                   = scm_ip_restriction.value.headers
         }
       }
+
+      scm_type                    = lookup(site_config.value, "scm_type", null)
+      scm_use_main_ip_restriction = length(var.scm_authorized_ips) > 0 || var.scm_authorized_subnet_ids != null ? false : true
+
 
       vnet_route_all_enabled = var.app_service_vnet_integration_subnet_id != null
 
@@ -230,9 +231,6 @@ resource "azurerm_linux_web_app_slot" "app_service_linux_slot" {
       use_32_bit_worker        = lookup(site_config.value, "use_32_bit_worker", false)
       websockets_enabled       = lookup(site_config.value, "websockets_enabled", false)
 
-      scm_type                    = lookup(site_config.value, "scm_type", null)
-      scm_use_main_ip_restriction = length(var.scm_authorized_ips) > 0 || var.scm_authorized_subnet_ids != null ? false : true
-
       dynamic "ip_restriction" {
         for_each = concat(local.subnets, local.cidrs, local.service_tags)
         content {
@@ -258,6 +256,10 @@ resource "azurerm_linux_web_app_slot" "app_service_linux_slot" {
           headers                   = scm_ip_restriction.value.headers
         }
       }
+
+      scm_type                    = lookup(site_config.value, "scm_type", null)
+      scm_use_main_ip_restriction = length(var.scm_authorized_ips) > 0 || var.scm_authorized_subnet_ids != null ? false : true
+
 
       vnet_route_all_enabled = var.app_service_vnet_integration_subnet_id != null
 

--- a/modules/windows-web-app/r-appservice.tf
+++ b/modules/windows-web-app/r-appservice.tf
@@ -24,9 +24,6 @@ resource "azurerm_windows_web_app" "app_service_windows" {
       use_32_bit_worker        = lookup(site_config.value, "use_32_bit_worker", false)
       websockets_enabled       = lookup(site_config.value, "websockets_enabled", false)
 
-      scm_type                    = lookup(site_config.value, "scm_type", null)
-      scm_use_main_ip_restriction = length(var.scm_authorized_ips) > 0 || var.scm_authorized_subnet_ids != null ? false : true
-
       dynamic "ip_restriction" {
         for_each = concat(local.subnets, local.cidrs, local.service_tags)
         content {
@@ -52,6 +49,10 @@ resource "azurerm_windows_web_app" "app_service_windows" {
           headers                   = scm_ip_restriction.value.headers
         }
       }
+
+      scm_type                    = lookup(site_config.value, "scm_type", null)
+      scm_use_main_ip_restriction = length(var.scm_authorized_ips) > 0 || var.scm_authorized_subnet_ids != null ? false : true
+
 
       vnet_route_all_enabled = var.app_service_vnet_integration_subnet_id != null
 
@@ -230,9 +231,6 @@ resource "azurerm_windows_web_app_slot" "app_service_windows_slot" {
       use_32_bit_worker        = lookup(site_config.value, "use_32_bit_worker", false)
       websockets_enabled       = lookup(site_config.value, "websockets_enabled", false)
 
-      scm_type                    = lookup(site_config.value, "scm_type", null)
-      scm_use_main_ip_restriction = length(var.scm_authorized_ips) > 0 || var.scm_authorized_subnet_ids != null ? false : true
-
       dynamic "ip_restriction" {
         for_each = concat(local.subnets, local.cidrs, local.service_tags)
         content {
@@ -258,6 +256,10 @@ resource "azurerm_windows_web_app_slot" "app_service_windows_slot" {
           headers                   = scm_ip_restriction.value.headers
         }
       }
+
+      scm_type                    = lookup(site_config.value, "scm_type", null)
+      scm_use_main_ip_restriction = length(var.scm_authorized_ips) > 0 || var.scm_authorized_subnet_ids != null ? false : true
+
 
       vnet_route_all_enabled = var.app_service_vnet_integration_subnet_id != null
 

--- a/modules/windows-web-app/r-appservice.tf
+++ b/modules/windows-web-app/r-appservice.tf
@@ -24,10 +24,34 @@ resource "azurerm_windows_web_app" "app_service_windows" {
       use_32_bit_worker        = lookup(site_config.value, "use_32_bit_worker", false)
       websockets_enabled       = lookup(site_config.value, "websockets_enabled", false)
 
-      ip_restriction              = concat(local.subnets, local.cidrs, local.service_tags)
       scm_type                    = lookup(site_config.value, "scm_type", null)
       scm_use_main_ip_restriction = length(var.scm_authorized_ips) > 0 || var.scm_authorized_subnet_ids != null ? false : true
-      scm_ip_restriction          = concat(local.scm_subnets, local.scm_cidrs, local.scm_service_tags)
+
+      dynamic "ip_restriction" {
+        for_each = concat(local.subnets, local.cidrs, local.service_tags)
+        content {
+          name                      = ip_restriction.value.name
+          ip_address                = ip_restriction.value.ip_address
+          virtual_network_subnet_id = ip_restriction.value.virtual_network_subnet_id
+          service_tag               = ip_restriction.value.service_tag
+          priority                  = ip_restriction.value.priority
+          action                    = ip_restriction.value.action
+          headers                   = ip_restriction.value.headers
+        }
+      }
+
+      dynamic "scm_ip_restriction" {
+        for_each = concat(local.scm_subnets, local.scm_cidrs, local.scm_service_tags)
+        content {
+          name                      = scm_ip_restriction.value.name
+          ip_address                = scm_ip_restriction.value.ip_address
+          virtual_network_subnet_id = scm_ip_restriction.value.virtual_network_subnet_id
+          service_tag               = scm_ip_restriction.value.service_tag
+          priority                  = scm_ip_restriction.value.priority
+          action                    = scm_ip_restriction.value.action
+          headers                   = scm_ip_restriction.value.headers
+        }
+      }
 
       vnet_route_all_enabled = var.app_service_vnet_integration_subnet_id != null
 
@@ -206,10 +230,34 @@ resource "azurerm_windows_web_app_slot" "app_service_windows_slot" {
       use_32_bit_worker        = lookup(site_config.value, "use_32_bit_worker", false)
       websockets_enabled       = lookup(site_config.value, "websockets_enabled", false)
 
-      ip_restriction              = concat(local.subnets, local.cidrs, local.service_tags)
       scm_type                    = lookup(site_config.value, "scm_type", null)
       scm_use_main_ip_restriction = length(var.scm_authorized_ips) > 0 || var.scm_authorized_subnet_ids != null ? false : true
-      scm_ip_restriction          = concat(local.scm_subnets, local.scm_cidrs, local.scm_service_tags)
+
+      dynamic "ip_restriction" {
+        for_each = concat(local.subnets, local.cidrs, local.service_tags)
+        content {
+          name                      = ip_restriction.value.name
+          ip_address                = ip_restriction.value.ip_address
+          virtual_network_subnet_id = ip_restriction.value.virtual_network_subnet_id
+          service_tag               = ip_restriction.value.service_tag
+          priority                  = ip_restriction.value.priority
+          action                    = ip_restriction.value.action
+          headers                   = ip_restriction.value.headers
+        }
+      }
+
+      dynamic "scm_ip_restriction" {
+        for_each = concat(local.scm_subnets, local.scm_cidrs, local.scm_service_tags)
+        content {
+          name                      = scm_ip_restriction.value.name
+          ip_address                = scm_ip_restriction.value.ip_address
+          virtual_network_subnet_id = scm_ip_restriction.value.virtual_network_subnet_id
+          service_tag               = scm_ip_restriction.value.service_tag
+          priority                  = scm_ip_restriction.value.priority
+          action                    = scm_ip_restriction.value.action
+          headers                   = scm_ip_restriction.value.headers
+        }
+      }
 
       vnet_route_all_enabled = var.app_service_vnet_integration_subnet_id != null
 

--- a/modules/windows-web-app/r-appservice.tf
+++ b/modules/windows-web-app/r-appservice.tf
@@ -53,7 +53,6 @@ resource "azurerm_windows_web_app" "app_service_windows" {
       scm_type                    = lookup(site_config.value, "scm_type", null)
       scm_use_main_ip_restriction = length(var.scm_authorized_ips) > 0 || var.scm_authorized_subnet_ids != null ? false : true
 
-
       vnet_route_all_enabled = var.app_service_vnet_integration_subnet_id != null
 
       dynamic "application_stack" {
@@ -259,7 +258,6 @@ resource "azurerm_windows_web_app_slot" "app_service_windows_slot" {
 
       scm_type                    = lookup(site_config.value, "scm_type", null)
       scm_use_main_ip_restriction = length(var.scm_authorized_ips) > 0 || var.scm_authorized_subnet_ids != null ? false : true
-
 
       vnet_route_all_enabled = var.app_service_vnet_integration_subnet_id != null
 


### PR DESCRIPTION
It has been a long time that `ip_restriction` was a block in app service related resource, not an attribute. Therefore, we cannot assign a value to it using `=` operator;

If we do so, we will see this error:

![image](https://user-images.githubusercontent.com/118145156/231664505-536cce1a-0e73-4f35-9c7b-9fd062caaa69.png)

This issue was [already addressed in the function-app module](https://github.com/claranet/terraform-azurerm-function-app/blob/02f2d575b5187d7351440ffdc975502c3847ede7/modules/windows-function/r-function.tf#L59-L83); So, I took the same structure and re-used it in this PR.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Changes proposed in this pull request
- fixes the issue with `ip_restriction` config assignment
-
-

@claranet/fr-azure-reviewers
