### PR TITLE
Make `auth_settings` block conditional

### DIFF
--- a/modules/linux-web-app/r-appservice.tf
+++ b/modules/linux-web-app/r-appservice.tf
@@ -99,20 +99,23 @@ resource "azurerm_linux_web_app" "app_service_linux" {
     }
   }
 
-  auth_settings {
-    enabled                        = local.auth_settings.enabled
-    issuer                         = local.auth_settings.issuer
-    token_store_enabled            = local.auth_settings.token_store_enabled
-    unauthenticated_client_action  = local.auth_settings.unauthenticated_client_action
-    default_provider               = local.auth_settings.default_provider
-    allowed_external_redirect_urls = local.auth_settings.allowed_external_redirect_urls
+  dynamic "auth_settings" {
+    for_each = local.auth_settings.enabled ? ["enabled"] : []
+    content {
+      enabled                        = local.auth_settings.enabled
+      issuer                         = local.auth_settings.issuer
+      token_store_enabled            = local.auth_settings.token_store_enabled
+      unauthenticated_client_action  = local.auth_settings.unauthenticated_client_action
+      default_provider               = local.auth_settings.default_provider
+      allowed_external_redirect_urls = local.auth_settings.allowed_external_redirect_urls
 
-    dynamic "active_directory" {
-      for_each = local.auth_settings_active_directory.client_id == null ? [] : [local.auth_settings_active_directory]
-      content {
-        client_id         = local.auth_settings_active_directory.client_id
-        client_secret     = local.auth_settings_active_directory.client_secret
-        allowed_audiences = concat(formatlist("https://%s", [format("%s.azurewebsites.net", local.app_service_name)]), local.auth_settings_active_directory.allowed_audiences)
+      dynamic "active_directory" {
+        for_each = local.auth_settings_active_directory.client_id == null ? [] : [local.auth_settings_active_directory]
+        content {
+          client_id         = local.auth_settings_active_directory.client_id
+          client_secret     = local.auth_settings_active_directory.client_secret
+          allowed_audiences = concat(formatlist("https://%s", [format("%s.azurewebsites.net", local.app_service_name)]), local.auth_settings_active_directory.allowed_audiences)
+        }
       }
     }
   }
@@ -297,21 +300,24 @@ resource "azurerm_linux_web_app_slot" "app_service_linux_slot" {
       value = lookup(connection_string.value, "value", null)
     }
   }
+  
+  dynamic "auth_settings" {
+    for_each = local.auth_settings.enabled ? ["enabled"] : []
+    content {
+      enabled                        = local.auth_settings.enabled
+      issuer                         = local.auth_settings.issuer
+      token_store_enabled            = local.auth_settings.token_store_enabled
+      unauthenticated_client_action  = local.auth_settings.unauthenticated_client_action
+      default_provider               = local.auth_settings.default_provider
+      allowed_external_redirect_urls = local.auth_settings.allowed_external_redirect_urls
 
-  auth_settings {
-    enabled                        = local.auth_settings.enabled
-    issuer                         = local.auth_settings.issuer
-    token_store_enabled            = local.auth_settings.token_store_enabled
-    unauthenticated_client_action  = local.auth_settings.unauthenticated_client_action
-    default_provider               = local.auth_settings.default_provider
-    allowed_external_redirect_urls = local.auth_settings.allowed_external_redirect_urls
-
-    dynamic "active_directory" {
-      for_each = local.auth_settings_active_directory.client_id == null ? [] : [local.auth_settings_active_directory]
-      content {
-        client_id         = local.auth_settings_active_directory.client_id
-        client_secret     = local.auth_settings_active_directory.client_secret
-        allowed_audiences = concat(formatlist("https://%s", [format("%s.azurewebsites.net", local.app_service_name)]), local.auth_settings_active_directory.allowed_audiences)
+      dynamic "active_directory" {
+        for_each = local.auth_settings_active_directory.client_id == null ? [] : [local.auth_settings_active_directory]
+        content {
+          client_id         = local.auth_settings_active_directory.client_id
+          client_secret     = local.auth_settings_active_directory.client_secret
+          allowed_audiences = concat(formatlist("https://%s", [format("%s.azurewebsites.net", local.app_service_name)]), local.auth_settings_active_directory.allowed_audiences)
+        }
       }
     }
   }

--- a/modules/linux-web-app/r-appservice.tf
+++ b/modules/linux-web-app/r-appservice.tf
@@ -300,7 +300,7 @@ resource "azurerm_linux_web_app_slot" "app_service_linux_slot" {
       value = lookup(connection_string.value, "value", null)
     }
   }
-  
+
   dynamic "auth_settings" {
     for_each = local.auth_settings.enabled ? ["enabled"] : []
     content {

--- a/modules/windows-web-app/r-appservice.tf
+++ b/modules/windows-web-app/r-appservice.tf
@@ -99,20 +99,23 @@ resource "azurerm_windows_web_app" "app_service_windows" {
     }
   }
 
-  auth_settings {
-    enabled                        = local.auth_settings.enabled
-    issuer                         = local.auth_settings.issuer
-    token_store_enabled            = local.auth_settings.token_store_enabled
-    unauthenticated_client_action  = local.auth_settings.unauthenticated_client_action
-    default_provider               = local.auth_settings.default_provider
-    allowed_external_redirect_urls = local.auth_settings.allowed_external_redirect_urls
+  dynamic "auth_settings" {
+    for_each = local.auth_settings.enabled ? ["enabled"] : []
+    content {
+      enabled                        = local.auth_settings.enabled
+      issuer                         = local.auth_settings.issuer
+      token_store_enabled            = local.auth_settings.token_store_enabled
+      unauthenticated_client_action  = local.auth_settings.unauthenticated_client_action
+      default_provider               = local.auth_settings.default_provider
+      allowed_external_redirect_urls = local.auth_settings.allowed_external_redirect_urls
 
-    dynamic "active_directory" {
-      for_each = local.auth_settings_active_directory.client_id == null ? [] : [local.auth_settings_active_directory]
-      content {
-        client_id         = local.auth_settings_active_directory.client_id
-        client_secret     = local.auth_settings_active_directory.client_secret
-        allowed_audiences = concat(formatlist("https://%s", [format("%s.azurewebsites.net", local.app_service_name)]), local.auth_settings_active_directory.allowed_audiences)
+      dynamic "active_directory" {
+        for_each = local.auth_settings_active_directory.client_id == null ? [] : [local.auth_settings_active_directory]
+        content {
+          client_id         = local.auth_settings_active_directory.client_id
+          client_secret     = local.auth_settings_active_directory.client_secret
+          allowed_audiences = concat(formatlist("https://%s", [format("%s.azurewebsites.net", local.app_service_name)]), local.auth_settings_active_directory.allowed_audiences)
+        }
       }
     }
   }
@@ -298,20 +301,23 @@ resource "azurerm_windows_web_app_slot" "app_service_windows_slot" {
     }
   }
 
-  auth_settings {
-    enabled                        = local.auth_settings.enabled
-    issuer                         = local.auth_settings.issuer
-    token_store_enabled            = local.auth_settings.token_store_enabled
-    unauthenticated_client_action  = local.auth_settings.unauthenticated_client_action
-    default_provider               = local.auth_settings.default_provider
-    allowed_external_redirect_urls = local.auth_settings.allowed_external_redirect_urls
+  dynamic "auth_settings" {
+    for_each = local.auth_settings.enabled ? ["enabled"] : []
+    content {
+      enabled                        = local.auth_settings.enabled
+      issuer                         = local.auth_settings.issuer
+      token_store_enabled            = local.auth_settings.token_store_enabled
+      unauthenticated_client_action  = local.auth_settings.unauthenticated_client_action
+      default_provider               = local.auth_settings.default_provider
+      allowed_external_redirect_urls = local.auth_settings.allowed_external_redirect_urls
 
-    dynamic "active_directory" {
-      for_each = local.auth_settings_active_directory.client_id == null ? [] : [local.auth_settings_active_directory]
-      content {
-        client_id         = local.auth_settings_active_directory.client_id
-        client_secret     = local.auth_settings_active_directory.client_secret
-        allowed_audiences = concat(formatlist("https://%s", [format("%s.azurewebsites.net", local.app_service_name)]), local.auth_settings_active_directory.allowed_audiences)
+      dynamic "active_directory" {
+        for_each = local.auth_settings_active_directory.client_id == null ? [] : [local.auth_settings_active_directory]
+        content {
+          client_id         = local.auth_settings_active_directory.client_id
+          client_secret     = local.auth_settings_active_directory.client_secret
+          allowed_audiences = concat(formatlist("https://%s", [format("%s.azurewebsites.net", local.app_service_name)]), local.auth_settings_active_directory.allowed_audiences)
+        }
       }
     }
   }


### PR DESCRIPTION
Hi team

Currently, the `auth_settings` block is not conditional; But it seems that AzureRM API ignores this block when `local.auth_settings.enabled == false`, hence there would be no track if this block in the TF state;

This issue, causes that every time TF plans the deployment, it shows a drift for this block;

![image](https://user-images.githubusercontent.com/118145156/236394633-6688bfc7-31bb-498b-975e-a2989fca9606.png)

This change makes the block conditional, so it is never sent to AzureRM API if `local.auth_settings.enabled == false`

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [n/a] New feature (non-breaking change which adds functionality)
- [n/a] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [n/a] This change requires a documentation update

## Changes proposed in this pull request

- Make `auth_settings` block conditional in the app and its slots

@claranet/fr-azure-reviewers
