### PR TITLE
Fix auth_settings_v2 null parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# Unreleased
+
+Fixed
+  * Fix variable `auth_settings_v2` null value error
+
 # v7.8.0 - 2023-10-10
 
 Changed

--- a/modules/container-web-app/locals.tf
+++ b/modules/container-web-app/locals.tf
@@ -121,6 +121,10 @@ locals {
     allowed_audiences = []
   }
 
+  auth_settings_v2 = merge({
+    auth_enabled = false
+  }, var.auth_settings_v2)
+
   auth_settings_v2_login_default = {
     token_store_enabled               = false
     token_refresh_extension_time      = 72

--- a/modules/container-web-app/r-appservice.tf
+++ b/modules/container-web-app/r-appservice.tf
@@ -116,7 +116,7 @@ resource "azurerm_linux_web_app" "app_service_linux_container" {
   }
 
   dynamic "auth_settings_v2" {
-    for_each = lookup(var.auth_settings_v2, "auth_enabled", false) ? [var.auth_settings_v2] : []
+    for_each = lookup(local.auth_settings_v2, "auth_enabled", false) ? [local.auth_settings_v2] : []
     content {
       auth_enabled                            = lookup(auth_settings_v2.value, "auth_enabled", false)
       runtime_version                         = lookup(auth_settings_v2.value, "runtime_version", "~1")
@@ -132,7 +132,7 @@ resource "azurerm_linux_web_app" "app_service_linux_container" {
       forward_proxy_custom_scheme_header_name = lookup(auth_settings_v2.value, "forward_proxy_custom_scheme_header_name", null)
 
       dynamic "apple_v2" {
-        for_each = try(var.auth_settings_v2.apple_v2[*], [])
+        for_each = try(local.auth_settings_v2.apple_v2[*], [])
         content {
           client_id                  = lookup(apple_v2.value, "client_id", null)
           client_secret_setting_name = lookup(apple_v2.value, "client_secret_setting_name", null)
@@ -140,8 +140,7 @@ resource "azurerm_linux_web_app" "app_service_linux_container" {
       }
 
       dynamic "active_directory_v2" {
-        for_each = try(var.auth_settings_v2.active_directory_v2[*], [])
-
+        for_each = try(local.auth_settings_v2.active_directory_v2[*], [])
         content {
           client_id                            = lookup(active_directory_v2.value, "client_id", null)
           tenant_auth_endpoint                 = lookup(active_directory_v2.value, "tenant_auth_endpoint", null)
@@ -158,14 +157,14 @@ resource "azurerm_linux_web_app" "app_service_linux_container" {
       }
 
       dynamic "azure_static_web_app_v2" {
-        for_each = try(var.auth_settings_v2.azure_static_web_app_v2[*], [])
+        for_each = try(local.auth_settings_v2.azure_static_web_app_v2[*], [])
         content {
           client_id = lookup(azure_static_web_app_v2.value, "client_id", null)
         }
       }
 
       dynamic "custom_oidc_v2" {
-        for_each = try(var.auth_settings_v2.custom_oidc_v2[*], [])
+        for_each = try(local.auth_settings_v2.custom_oidc_v2[*], [])
         content {
           name                          = lookup(custom_oidc_v2.value, "name", null)
           client_id                     = lookup(custom_oidc_v2.value, "client_id", null)
@@ -182,7 +181,7 @@ resource "azurerm_linux_web_app" "app_service_linux_container" {
       }
 
       dynamic "facebook_v2" {
-        for_each = try(var.auth_settings_v2.facebook_v2[*], [])
+        for_each = try(local.auth_settings_v2.facebook_v2[*], [])
         content {
           app_id                  = lookup(facebook_v2.value, "app_id", null)
           app_secret_setting_name = lookup(facebook_v2.value, "app_secret_setting_name", null)
@@ -192,7 +191,7 @@ resource "azurerm_linux_web_app" "app_service_linux_container" {
       }
 
       dynamic "github_v2" {
-        for_each = try(var.auth_settings_v2.github_v2[*], [])
+        for_each = try(local.auth_settings_v2.github_v2[*], [])
         content {
           client_id                  = lookup(github_v2.value, "client_id", null)
           client_secret_setting_name = lookup(github_v2.value, "client_secret_setting_name", null)
@@ -201,7 +200,7 @@ resource "azurerm_linux_web_app" "app_service_linux_container" {
       }
 
       dynamic "google_v2" {
-        for_each = try(var.auth_settings_v2.google_v2[*], [])
+        for_each = try(local.auth_settings_v2.google_v2[*], [])
         content {
           client_id                  = lookup(google_v2.value, "client_id", null)
           client_secret_setting_name = lookup(google_v2.value, "client_secret_setting_name", null)
@@ -211,7 +210,7 @@ resource "azurerm_linux_web_app" "app_service_linux_container" {
       }
 
       dynamic "microsoft_v2" {
-        for_each = try(var.auth_settings_v2.microsoft_v2[*], [])
+        for_each = try(local.auth_settings_v2.microsoft_v2[*], [])
         content {
           client_id                  = lookup(microsoft_v2.value, "client_id", null)
           client_secret_setting_name = lookup(microsoft_v2.value, "client_secret_setting_name", null)
@@ -221,7 +220,7 @@ resource "azurerm_linux_web_app" "app_service_linux_container" {
       }
 
       dynamic "twitter_v2" {
-        for_each = try(var.auth_settings_v2.twitter_v2[*], [])
+        for_each = try(local.auth_settings_v2.twitter_v2[*], [])
         content {
           consumer_key                 = lookup(twitter_v2.value, "consumer_key", null)
           consumer_secret_setting_name = lookup(twitter_v2.value, "consumer_secret_setting_name", null)

--- a/modules/linux-web-app/locals.tf
+++ b/modules/linux-web-app/locals.tf
@@ -119,6 +119,10 @@ locals {
     allowed_audiences = []
   }
 
+  auth_settings_v2 = merge({
+    auth_enabled = false
+  }, var.auth_settings_v2)
+
   auth_settings_v2_login_default = {
     token_store_enabled               = false
     token_refresh_extension_time      = 72

--- a/modules/linux-web-app/r-appservice.tf
+++ b/modules/linux-web-app/r-appservice.tf
@@ -124,7 +124,7 @@ resource "azurerm_linux_web_app" "app_service_linux" {
   }
 
   dynamic "auth_settings_v2" {
-    for_each = lookup(var.auth_settings_v2, "auth_enabled", false) ? [var.auth_settings_v2] : []
+    for_each = lookup(local.auth_settings_v2, "auth_enabled", false) ? [local.auth_settings_v2] : []
     content {
       auth_enabled                            = lookup(auth_settings_v2.value, "auth_enabled", false)
       runtime_version                         = lookup(auth_settings_v2.value, "runtime_version", "~1")
@@ -140,7 +140,7 @@ resource "azurerm_linux_web_app" "app_service_linux" {
       forward_proxy_custom_scheme_header_name = lookup(auth_settings_v2.value, "forward_proxy_custom_scheme_header_name", null)
 
       dynamic "apple_v2" {
-        for_each = try(var.auth_settings_v2.apple_v2[*], [])
+        for_each = try(local.auth_settings_v2.apple_v2[*], [])
         content {
           client_id                  = lookup(apple_v2.value, "client_id", null)
           client_secret_setting_name = lookup(apple_v2.value, "client_secret_setting_name", null)
@@ -148,7 +148,7 @@ resource "azurerm_linux_web_app" "app_service_linux" {
       }
 
       dynamic "active_directory_v2" {
-        for_each = try(var.auth_settings_v2.active_directory_v2[*], [])
+        for_each = try(local.auth_settings_v2.active_directory_v2[*], [])
 
         content {
           client_id                            = lookup(active_directory_v2.value, "client_id", null)
@@ -166,14 +166,14 @@ resource "azurerm_linux_web_app" "app_service_linux" {
       }
 
       dynamic "azure_static_web_app_v2" {
-        for_each = try(var.auth_settings_v2.azure_static_web_app_v2[*], [])
+        for_each = try(local.auth_settings_v2.azure_static_web_app_v2[*], [])
         content {
           client_id = lookup(azure_static_web_app_v2.value, "client_id", null)
         }
       }
 
       dynamic "custom_oidc_v2" {
-        for_each = try(var.auth_settings_v2.custom_oidc_v2[*], [])
+        for_each = try(local.auth_settings_v2.custom_oidc_v2[*], [])
         content {
           name                          = lookup(custom_oidc_v2.value, "name", null)
           client_id                     = lookup(custom_oidc_v2.value, "client_id", null)
@@ -190,7 +190,7 @@ resource "azurerm_linux_web_app" "app_service_linux" {
       }
 
       dynamic "facebook_v2" {
-        for_each = try(var.auth_settings_v2.facebook_v2[*], [])
+        for_each = try(local.auth_settings_v2.facebook_v2[*], [])
         content {
           app_id                  = lookup(facebook_v2.value, "app_id", null)
           app_secret_setting_name = lookup(facebook_v2.value, "app_secret_setting_name", null)
@@ -200,7 +200,7 @@ resource "azurerm_linux_web_app" "app_service_linux" {
       }
 
       dynamic "github_v2" {
-        for_each = try(var.auth_settings_v2.github_v2[*], [])
+        for_each = try(local.auth_settings_v2.github_v2[*], [])
         content {
           client_id                  = lookup(github_v2.value, "client_id", null)
           client_secret_setting_name = lookup(github_v2.value, "client_secret_setting_name", null)
@@ -209,7 +209,7 @@ resource "azurerm_linux_web_app" "app_service_linux" {
       }
 
       dynamic "google_v2" {
-        for_each = try(var.auth_settings_v2.google_v2[*], [])
+        for_each = try(local.auth_settings_v2.google_v2[*], [])
         content {
           client_id                  = lookup(google_v2.value, "client_id", null)
           client_secret_setting_name = lookup(google_v2.value, "client_secret_setting_name", null)
@@ -219,7 +219,7 @@ resource "azurerm_linux_web_app" "app_service_linux" {
       }
 
       dynamic "microsoft_v2" {
-        for_each = try(var.auth_settings_v2.microsoft_v2[*], [])
+        for_each = try(local.auth_settings_v2.microsoft_v2[*], [])
         content {
           client_id                  = lookup(microsoft_v2.value, "client_id", null)
           client_secret_setting_name = lookup(microsoft_v2.value, "client_secret_setting_name", null)
@@ -229,7 +229,7 @@ resource "azurerm_linux_web_app" "app_service_linux" {
       }
 
       dynamic "twitter_v2" {
-        for_each = try(var.auth_settings_v2.twitter_v2[*], [])
+        for_each = try(local.auth_settings_v2.twitter_v2[*], [])
         content {
           consumer_key                 = lookup(twitter_v2.value, "consumer_key", null)
           consumer_secret_setting_name = lookup(twitter_v2.value, "consumer_secret_setting_name", null)

--- a/modules/windows-web-app/locals.tf
+++ b/modules/windows-web-app/locals.tf
@@ -121,6 +121,10 @@ locals {
     allowed_audiences = []
   }
 
+  auth_settings_v2 = merge({
+    auth_enabled = false
+  }, var.auth_settings_v2)
+
   auth_settings_v2_login_default = {
     token_store_enabled               = false
     token_refresh_extension_time      = 72

--- a/modules/windows-web-app/r-appservice.tf
+++ b/modules/windows-web-app/r-appservice.tf
@@ -124,7 +124,7 @@ resource "azurerm_windows_web_app" "app_service_windows" {
   }
 
   dynamic "auth_settings_v2" {
-    for_each = lookup(var.auth_settings_v2, "auth_enabled", false) ? [var.auth_settings_v2] : []
+    for_each = lookup(local.auth_settings_v2, "auth_enabled", false) ? [local.auth_settings_v2] : []
     content {
       auth_enabled                            = lookup(auth_settings_v2.value, "auth_enabled", false)
       runtime_version                         = lookup(auth_settings_v2.value, "runtime_version", "~1")
@@ -140,7 +140,7 @@ resource "azurerm_windows_web_app" "app_service_windows" {
       forward_proxy_custom_scheme_header_name = lookup(auth_settings_v2.value, "forward_proxy_custom_scheme_header_name", null)
 
       dynamic "apple_v2" {
-        for_each = try(var.auth_settings_v2.apple_v2[*], [])
+        for_each = try(local.auth_settings_v2.apple_v2[*], [])
         content {
           client_id                  = lookup(apple_v2.value, "client_id", null)
           client_secret_setting_name = lookup(apple_v2.value, "client_secret_setting_name", null)
@@ -148,7 +148,7 @@ resource "azurerm_windows_web_app" "app_service_windows" {
       }
 
       dynamic "active_directory_v2" {
-        for_each = try(var.auth_settings_v2.active_directory_v2[*], [])
+        for_each = try(local.auth_settings_v2.active_directory_v2[*], [])
 
         content {
           client_id                            = lookup(active_directory_v2.value, "client_id", null)
@@ -166,14 +166,14 @@ resource "azurerm_windows_web_app" "app_service_windows" {
       }
 
       dynamic "azure_static_web_app_v2" {
-        for_each = try(var.auth_settings_v2.azure_static_web_app_v2[*], [])
+        for_each = try(local.auth_settings_v2.azure_static_web_app_v2[*], [])
         content {
           client_id = lookup(azure_static_web_app_v2.value, "client_id", null)
         }
       }
 
       dynamic "custom_oidc_v2" {
-        for_each = try(var.auth_settings_v2.custom_oidc_v2[*], [])
+        for_each = try(local.auth_settings_v2.custom_oidc_v2[*], [])
         content {
           name                          = lookup(custom_oidc_v2.value, "name", null)
           client_id                     = lookup(custom_oidc_v2.value, "client_id", null)
@@ -190,7 +190,7 @@ resource "azurerm_windows_web_app" "app_service_windows" {
       }
 
       dynamic "facebook_v2" {
-        for_each = try(var.auth_settings_v2.facebook_v2[*], [])
+        for_each = try(local.auth_settings_v2.facebook_v2[*], [])
         content {
           app_id                  = lookup(facebook_v2.value, "app_id", null)
           app_secret_setting_name = lookup(facebook_v2.value, "app_secret_setting_name", null)
@@ -200,7 +200,7 @@ resource "azurerm_windows_web_app" "app_service_windows" {
       }
 
       dynamic "github_v2" {
-        for_each = try(var.auth_settings_v2.github_v2[*], [])
+        for_each = try(local.auth_settings_v2.github_v2[*], [])
         content {
           client_id                  = lookup(github_v2.value, "client_id", null)
           client_secret_setting_name = lookup(github_v2.value, "client_secret_setting_name", null)
@@ -209,7 +209,7 @@ resource "azurerm_windows_web_app" "app_service_windows" {
       }
 
       dynamic "google_v2" {
-        for_each = try(var.auth_settings_v2.google_v2[*], [])
+        for_each = try(local.auth_settings_v2.google_v2[*], [])
         content {
           client_id                  = lookup(google_v2.value, "client_id", null)
           client_secret_setting_name = lookup(google_v2.value, "client_secret_setting_name", null)
@@ -219,7 +219,7 @@ resource "azurerm_windows_web_app" "app_service_windows" {
       }
 
       dynamic "microsoft_v2" {
-        for_each = try(var.auth_settings_v2.microsoft_v2[*], [])
+        for_each = try(local.auth_settings_v2.microsoft_v2[*], [])
         content {
           client_id                  = lookup(microsoft_v2.value, "client_id", null)
           client_secret_setting_name = lookup(microsoft_v2.value, "client_secret_setting_name", null)
@@ -229,7 +229,7 @@ resource "azurerm_windows_web_app" "app_service_windows" {
       }
 
       dynamic "twitter_v2" {
-        for_each = try(var.auth_settings_v2.twitter_v2[*], [])
+        for_each = try(local.auth_settings_v2.twitter_v2[*], [])
         content {
           consumer_key                 = lookup(twitter_v2.value, "consumer_key", null)
           consumer_secret_setting_name = lookup(twitter_v2.value, "consumer_secret_setting_name", null)


### PR DESCRIPTION
## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

I'm getting error when auth_settings_v2 is null.

Error:
╷
│ Error: Invalid function argument
│ 
│   on terraform-azurerm-app-service/modules/container-web-app/r-appservice.tf line 118, in resource "azurerm_linux_web_app" "app_service_linux_container":
│  118:     for_each = lookup(var.auth_settings_v2, "auth_enabled", false) ? [var.auth_settings_v2] : []
│     ├────────────────
│     │ while calling lookup(inputMap, key, default...)
│     │ var.auth_settings_v2 is null
│ 
│ Invalid value for "inputMap" parameter: argument must not be null.

@claranet/fr-azure-reviewers
